### PR TITLE
build: optimize the release flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@
 #
 
 VERSION_PATH=main
-VERSION ?= dev-$(shell git rev-parse --short HEAD)
-GIT_COMMIT=$(shell git rev-parse HEAD)
+-include .env
+VERSION ?= $(if $(RELEASE_VERSION),$(RELEASE_VERSION),dev-$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown))
+GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 MKDIR_P = mkdir -p
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -73,8 +73,8 @@ make release-push-candidate
 ```
 
 This script:
-1. SVN-checks out `https://dist.apache.org/repos/dist/dev/skywalking/`
-2. Copies the tarballs, signature, and checksum into `skywalking/mcp/${VERSION}/`
+1. SVN-checks out `https://dist.apache.org/repos/dist/dev/skywalking/mcp/`
+2. Copies the tarballs, signature, and checksum into `mcp/${VERSION}/`
 3. Commits to SVN
 4. Prints a vote email template to stdout
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,7 +43,7 @@ git push origin v${VERSION}
 
 ## Step 3 — Build and sign the artifacts
 
-`release.sh` resolves the version from the **latest tag reachable in the repo** (via `git describe --tags`), not from the `VERSION` env var. To ensure the artifacts are stamped with the intended version, use one of these approaches:
+`release.sh` resolves the version from the **latest tag reachable in the repo** (via `git describe --tags`), not from the `VERSION` env var. It also resolves a single release commit and uses that same commit for both the source archive and the binary build. To ensure the artifacts are stamped with the intended version, use one of these approaches:
 
 **Option A (recommended): set `RELEASE_VERSION` explicitly**
 
@@ -56,6 +56,8 @@ RELEASE_VERSION=${VERSION} make release-assembly
 If `v${VERSION}` is already the most recent tag, `make release-assembly` picks it up automatically without any env override.
 
 > If another newer tag exists in the repo, Option A is required to avoid building artifacts with the wrong version.
+
+By default, the release commit is resolved from tag `v${VERSION}` when it exists. You can override it explicitly with `RELEASE_GIT_COMMIT=<commit>` when you need to release from a specific commit.
 
 This runs three steps in sequence:
 1. `release-source` — creates `build/skywalking-mcp-${VERSION}-src.tgz`

--- a/scripts/push-release.sh
+++ b/scripts/push-release.sh
@@ -43,21 +43,21 @@ RELEASE_COMMIT=$(git -C "${ROOTDIR}" rev-list -n 1 "${TAG_NAME}")
 pushd ${BUILDDIR}
 trap 'popd' EXIT
 
-rm -rf skywalking
+rm -rf mcp
 
-svn co https://dist.apache.org/repos/dist/dev/skywalking/
-mkdir -p skywalking/mcp/"$VERSION"
+svn co https://dist.apache.org/repos/dist/dev/skywalking/mcp/
+mkdir -p mcp/"$VERSION"
 BINARY_TGZ="${PRODUCT_NAME}.tgz"
 SRC_TGZ="${PRODUCT_NAME}-src.tgz"
-cp "${BINARY_TGZ}" skywalking/mcp/"$VERSION"
-cp "${BINARY_TGZ}.asc" skywalking/mcp/"$VERSION"
-cp "${BINARY_TGZ}.sha512" skywalking/mcp/"$VERSION"
-cp "${SRC_TGZ}" skywalking/mcp/"$VERSION"
-cp "${SRC_TGZ}.asc" skywalking/mcp/"$VERSION"
-cp "${SRC_TGZ}.sha512" skywalking/mcp/"$VERSION"
+cp "${BINARY_TGZ}" mcp/"$VERSION"
+cp "${BINARY_TGZ}.asc" mcp/"$VERSION"
+cp "${BINARY_TGZ}.sha512" mcp/"$VERSION"
+cp "${SRC_TGZ}" mcp/"$VERSION"
+cp "${SRC_TGZ}.asc" mcp/"$VERSION"
+cp "${SRC_TGZ}.sha512" mcp/"$VERSION"
 
-cd skywalking && svn add --parents mcp/"$VERSION" && svn commit -m "Draft Apache SkyWalking MCP release $VERSION"
-cd mcp/"$VERSION"
+cd mcp && svn add --parents "$VERSION" && svn commit -m "Draft Apache SkyWalking MCP release $VERSION"
+cd "$VERSION"
 
 cat << EOF
 =========================================================================

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -65,8 +65,22 @@ resolve_release_version() {
     echo "dev-unknown"
 }
 
+resolve_release_commit() {
+    if [ -n "${RELEASE_GIT_COMMIT:-}" ]; then
+        git -C "${ROOTDIR}" rev-parse "${RELEASE_GIT_COMMIT}"
+        return 0
+    fi
+
+    if git -C "${ROOTDIR}" show-ref --tags --verify "refs/tags/v${RELEASE_VERSION}" >/dev/null 2>&1; then
+        git -C "${ROOTDIR}" rev-list -n 1 "v${RELEASE_VERSION}"
+        return 0
+    fi
+
+    git -C "${ROOTDIR}" rev-parse HEAD
+}
+
 RELEASE_VERSION=$(resolve_release_version)
-RELEASE_GIT_COMMIT=$(git -C "${ROOTDIR}" rev-parse HEAD)
+RELEASE_GIT_COMMIT=$(resolve_release_commit)
 
 SOURCE_FILE_NAME=skywalking-mcp-${RELEASE_VERSION}-src.tgz
 SOURCE_FILE=${BUILDDIR}/${SOURCE_FILE_NAME}
@@ -109,7 +123,7 @@ source(){
 
         rm -rf "${SOURCE_FILE}"
         mkdir -p "${srcdir}"
-        git -C "${ROOTDIR}" archive --format=tar HEAD | tar -xf - -C "${srcdir}"
+        git -C "${ROOTDIR}" archive --format=tar "${RELEASE_GIT_COMMIT}" | tar -xf - -C "${srcdir}"
         echo "RELEASE_VERSION=${RELEASE_VERSION}" > "${srcdir}/.env"
         tar -czf "${tmpdir}/${SOURCE_FILE_NAME}" -C "${srcdir}" .
 
@@ -141,7 +155,7 @@ parseCmdLine(){
             b) binary ;;
             s) source ;;
             k) sign "${OPTARG}" ;;
-            v) echo "Resolved RELEASE_VERSION=${RELEASE_VERSION}" ;;
+            v) echo "Resolved RELEASE_VERSION=${RELEASE_VERSION}" && echo "Resolved RELEASE_GIT_COMMIT=${RELEASE_GIT_COMMIT}" ;;
             h) usage ;;
             \?) usage ;;
         esac

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -30,6 +30,20 @@ require_cmd() {
     fi
 }
 
+has_git_worktree() {
+    command -v git >/dev/null 2>&1 && git -C "${ROOTDIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+require_git_worktree() {
+    if ! has_git_worktree; then
+        cat <<EOF >&2
+Error: assembling the source package requires a functional Git worktree at ${ROOTDIR}.
+Run this command from a Git checkout, or reuse a previously generated source archive when building/signing without Git metadata.
+EOF
+        exit 1
+    fi
+}
+
 resolve_release_version() {
     # 1) Explicit environment override
     if [ -n "${RELEASE_VERSION:-}" ]; then
@@ -38,7 +52,7 @@ resolve_release_version() {
     fi
 
     # 2) Derive from Git tags when available
-    if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if has_git_worktree; then
         if latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>/dev/null); then
             echo "${latest_tag#v}"
             return 0
@@ -67,16 +81,21 @@ resolve_release_version() {
 
 resolve_release_commit() {
     if [ -n "${RELEASE_GIT_COMMIT:-}" ]; then
-        git -C "${ROOTDIR}" rev-parse "${RELEASE_GIT_COMMIT}"
+        echo "${RELEASE_GIT_COMMIT}"
         return 0
     fi
 
-    if git -C "${ROOTDIR}" show-ref --tags --verify "refs/tags/v${RELEASE_VERSION}" >/dev/null 2>&1; then
+    if has_git_worktree && git -C "${ROOTDIR}" show-ref --tags --verify "refs/tags/v${RELEASE_VERSION}" >/dev/null 2>&1; then
         git -C "${ROOTDIR}" rev-list -n 1 "v${RELEASE_VERSION}"
         return 0
     fi
 
-    git -C "${ROOTDIR}" rev-parse HEAD
+    if has_git_worktree; then
+        git -C "${ROOTDIR}" rev-parse HEAD
+        return 0
+    fi
+
+    echo "unknown"
 }
 
 RELEASE_VERSION=$(resolve_release_version)
@@ -114,6 +133,8 @@ binary(){
 
 source(){
     require_cmd tar
+    require_git_worktree
+    require_cmd git
 
     (
         tmpdir=$(mktemp -d)
@@ -181,8 +202,6 @@ EOF
 #
 # main
 #
-
-require_cmd git
 
 ret=0
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -66,6 +66,7 @@ resolve_release_version() {
 }
 
 RELEASE_VERSION=$(resolve_release_version)
+RELEASE_GIT_COMMIT=$(git -C "${ROOTDIR}" rev-parse HEAD)
 
 SOURCE_FILE_NAME=skywalking-mcp-${RELEASE_VERSION}-src.tgz
 SOURCE_FILE=${BUILDDIR}/${SOURCE_FILE_NAME}
@@ -84,7 +85,7 @@ binary(){
 
         tar -xvf "${SOURCE_FILE}" -C "${tmpdir}"
         cd "${tmpdir}"
-        make build
+        make build VERSION="${RELEASE_VERSION}" GIT_COMMIT="${RELEASE_GIT_COMMIT}"
 
         bindir=./build
         mkdir -p "${bindir}/bin"
@@ -104,19 +105,13 @@ source(){
         tmpdir=$(mktemp -d)
         trap 'rm -rf "${tmpdir}"' EXIT
 
+        srcdir="${tmpdir}/src"
+
         rm -rf "${SOURCE_FILE}"
-        cd "${ROOTDIR}"
-        echo "RELEASE_VERSION=${RELEASE_VERSION}" > .env
-        tar \
-        --exclude=".DS_Store" \
-        --exclude=".github" \
-        --exclude=".gitignore" \
-        --exclude=".asf.yaml" \
-        --exclude=".idea" \
-        --exclude=".vscode" \
-        --exclude="bin" \
-        -czf "${tmpdir}/${SOURCE_FILE_NAME}" \
-        .
+        mkdir -p "${srcdir}"
+        git -C "${ROOTDIR}" archive --format=tar HEAD | tar -xf - -C "${srcdir}"
+        echo "RELEASE_VERSION=${RELEASE_VERSION}" > "${srcdir}/.env"
+        tar -czf "${tmpdir}/${SOURCE_FILE_NAME}" -C "${srcdir}" .
 
         mkdir -p "${BUILDDIR}"
         mv "${tmpdir}/${SOURCE_FILE_NAME}" "${BUILDDIR}"


### PR DESCRIPTION
This PR tightens the release flow by reducing the source package to release relevant files only and narrowing the SVN upload working copy to the mcp directory.


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
